### PR TITLE
commit id on aws for multipart was truncated

### DIFF
--- a/src/multipart.c
+++ b/src/multipart.c
@@ -36,7 +36,7 @@ typedef struct InitialMultipartData
     SimpleXml simpleXml;
     int len;
     S3MultipartInitialHandler *handler;
-    string_buffer(upload_id, 128);
+    string_buffer(upload_id, 256);
     void * userdata;
 } InitialMultipartData;
 

--- a/test/test.sh
+++ b/test/test.sh
@@ -23,13 +23,13 @@ if [ -z "$TEST_BUCKET_PREFIX" ]; then
 fi
 
 if [ -z "$S3_COMMAND" ]; then
-    S3_COMMAND=s3
+    S3_COMMAND="s3 -h"
 fi
 
 TEST_BUCKET=${TEST_BUCKET_PREFIX}.testbucket
 
-# Create the test bucket in EU
-echo "$S3_COMMAND create $TEST_BUCKET locationConstraint=EU"
+# Create the test bucket
+echo "$S3_COMMAND create $TEST_BUCKET"
 $S3_COMMAND create $TEST_BUCKET
 
 # List to find it
@@ -80,8 +80,8 @@ for i in `seq 0 9`; do
 done
 
 # List with all details
-echo "$S3_COMMAND list $TEST_BUCKET allDetails=1"
-$S3_COMMAND list $TEST_BUCKET allDetails=1
+echo "$S3_COMMAND list $TEST_BUCKET"
+$S3_COMMAND list $TEST_BUCKET
 
 COPY_BUCKET=${TEST_BUCKET_PREFIX}.copybucket
 
@@ -94,8 +94,8 @@ EOF
 $S3_COMMAND copy $TEST_BUCKET/key_5 $COPY_BUCKET/copykey
 
 # List the copy bucket
-echo "$S3_COMMAND list $COPY_BUCKET allDetails=1"
-$S3_COMMAND list $COPY_BUCKET allDetails=1
+echo "$S3_COMMAND list $COPY_BUCKET"
+$S3_COMMAND list $COPY_BUCKET
 
 # Compare the files
 rm -f key_5 copykey
@@ -124,8 +124,8 @@ $S3_COMMAND put $TEST_BUCKET/aclkey < /dev/null
 
 # Get the bucket acl
 rm -f acl
-echo "$S3_COMMAND getacl $TEST_BUCKET filename=acl allDetails=1"
-$S3_COMMAND getacl $TEST_BUCKET filename=acl allDetails=1
+echo "$S3_COMMAND getacl $TEST_BUCKET filename=acl"
+$S3_COMMAND getacl $TEST_BUCKET filename=acl
 
 # Add READ for all AWS users, and READ_ACP for everyone
 echo <<EOF >> acl
@@ -139,15 +139,15 @@ $S3_COMMAND setacl $TEST_BUCKET filename=acl
 
 # Test to make sure that it worked
 rm -f acl_new
-echo "$S3_COMMAND getacl $TEST_BUCKET filename=acl_new allDetails=1"
-$S3_COMMAND getacl $TEST_BUCKET filename=acl_new allDetails=1
+echo "$S3_COMMAND getacl $TEST_BUCKET filename=acl_new"
+$S3_COMMAND getacl $TEST_BUCKET filename=acl_new
 diff acl acl_new
 rm -f acl acl_new
 
 # Get the key acl
 rm -f acl
-echo "$S3_COMMAND getacl $TEST_BUCKET/aclkey filename=acl allDetails=1"
-$S3_COMMAND getacl $TEST_BUCKET/aclkey filename=acl allDetails=1
+echo "$S3_COMMAND getacl $TEST_BUCKET/aclkey filename=acl"
+$S3_COMMAND getacl $TEST_BUCKET/aclkey filename=acl
 
 # Add READ for all AWS users, and READ_ACP for everyone
 echo <<EOF >> acl
@@ -161,10 +161,21 @@ $S3_COMMAND setacl $TEST_BUCKET/aclkey filename=acl
 
 # Test to make sure that it worked
 rm -f acl_new
-echo "$S3_COMMAND getacl $TEST_BUCKET/aclkey filename=acl_new allDetails=1"
-$S3_COMMAND getacl $TEST_BUCKET/aclkey filename=acl_new allDetails=1
+echo "$S3_COMMAND getacl $TEST_BUCKET/aclkey filename=acl_new"
+$S3_COMMAND getacl $TEST_BUCKET/aclkey filename=acl_new
 diff acl acl_new
 rm -f acl acl_new
+
+# Check multipart file upload (>15MB)
+dd if=/dev/zero of=mpfile bs=1024k count=30
+echo "$S3_COMMAND put $TEST_BUCKET/mpfile filename=mpfile"
+$S3_COMMAND put $TEST_BUCKET/mpfile filename=mpfile
+echo "$S3_COMMAND get $TEST_BUCKET/mpfile filename=mpfile.get"
+$S3_COMMAND get $TEST_BUCKET/mpfile filename=mpfile.get
+diff mpfile mpfile.get
+echo "$S3_COMMAND delete $TEST_BUCKET/mpfile"
+$S3_COMMAND delete $TEST_BUCKET/mpfile
+rm -f mpfile mpfile.get
 
 # Remove the test file
 echo "$S3_COMMAND delete $TEST_BUCKET/aclkey"


### PR DESCRIPTION
the string returned from amazon in testing is
128 + null term for final length of 129
this was previously truncating the last char
resulting in an incorrect id when trying to
complete the upload

since there doesnt seem to be any documentation
on how long these could get from aws, double the
previous buffer length to 256 for now

bug:
$ ./s3 -h put testb/test filename=./test
Sending Part Seq 1, length=15728640

ERROR: ErrorNoSuchUpload
  Message: The specified upload does not exist. The upload ID may be
invalid, or the upload may have been aborted or completed.
  Extra Details:
    UploadId:
.yh43YCRYOhfHGAxy_WLPcVAlt.erMiqR2cgv78cdFPPUUa.qiJ.jIvxDlmCHVxyvcLQkztIs6lPmZZyefwl7XJ3gJSQcidWpq80bjxBIGn1NgJ6yUQlUVzrGuqBE2.
    RequestId: 2E96F0D8A8D5CC81
    HostId:
72aAmPpiGcH+gtz/PoZpLRnAA8+1XTxOxLIrznAfRMU8Rj7LObrntPCtpArA1r03S1ubxBjlCAU=

$ s3cmd multipart s3://testb
s3://testb/
Initiated   Path    Id
2015-10-30T17:47:02.000Z    s3://testb/test
.yh43YCRYOhfHGAxy_WLPcVAlt.erMiqR2cgv78cdFPPUUa.qiJ.jIvxDlmCHVxyvcLQkztIs6lPmZZyefwl7XJ3gJSQcidWpq80bjxBIGn1NgJ6yUQlUVzrGuqBE2.r

notice missing "r" from error UploadId above

fix:
$ ./s3 -h put testb/test filename=./test
Sending Part Seq 1, length=15728640
15712256 bytes remaining (50% complete) ...
...
32768 bytes remaining (99% complete) ...
16384 bytes remaining (99% complete) ...
