### PR TITLE
update RPM builds to match VSM

### DIFF
--- a/libs3.spec
+++ b/libs3.spec
@@ -1,12 +1,17 @@
+%{!?_version: %global _version 2.1}
+# add on official "dot" if we have a patched version
+%global release_vsm_patch %{?vsm_patch:.%{vsm_patch}}
+%global source_vsm_patch %{?vsm_patch:-%{vsm_patch}}
+
 Summary: C Library and Tools for Amazon S3 Access
 Name: libs3
 Version: %{_version}
-Release: vsm%{?dist}
+Release: vsm%{release_vsm_patch}%{?dist}
 License: LGPL
 Group: Networking/Utilities
 URL: http://sourceforge.net/projects/reallibs3
-Source0: %{name}-%{version}.tar.gz
-Buildroot: %{_tmppath}/%{name}-%{version}-%{release}-root
+Source0: %{name}-%{version}%{source_vsm_patch}.tar.gz
+BuildRoot: %{_tmppath}/%{name}-%{version}%{source_vsm_patch}-root
 # Want to include curl dependencies, but older Fedora Core uses curl-devel,
 # and newer Fedora Core uses libcurl-devel ... have to figure out how to
 # handle this problem, but for now, just don't check for any curl libraries
@@ -51,7 +56,7 @@ http://s3.amazonaws.com).  Its design goals are:
 
 
 %prep
-%setup -q -n %{name}-%{version}
+%setup -q -n %{name}-%{version}%{source_vsm_patch}
 
 %build
 BUILD=$RPM_BUILD_ROOT/build make exported

--- a/pkg-linux/GNUmakefile
+++ b/pkg-linux/GNUmakefile
@@ -32,8 +32,13 @@ MARKER = $(DEPTH)/MARKER
 RPM_DIR = $(HOME)/rpmbuild
 
 # fix up source name to be proper and polite
-PKG_SOURCE_VERSION = $(PKG_VERSION)
-RPM_NAME = $(PKG_VERSION).*.rpm
+ifneq ("$(VSM_PATCH)", "")
+    PKG_SOURCE_VERSION = $(PKG_VERSION)-$(VSM_PATCH)
+    RPM_NAME = $(PKG_VERSION)*$(VSM_PATCH).*.rpm
+else
+    PKG_SOURCE_VERSION = $(PKG_VERSION)
+    RPM_NAME = $(PKG_VERSION).*.rpm
+endif
 
 .PHONY: dist devdist
 dist:

--- a/pkg-linux/mock_rpmbuild.sh
+++ b/pkg-linux/mock_rpmbuild.sh
@@ -120,6 +120,12 @@ build_centos_65() {
     common_build
 }
 
+# Centos 6.6
+build_centos_66() {
+    MOCK_CONFIG=${MOCK_CONFIG:-"centos-6.6-x86_64"}
+    common_build
+}
+
 # Centos 6.x (latest), currently 6.6
 build_centos_6x() {
     MOCK_CONFIG=${MOCK_CONFIG:-"epel-6-x86_64"}
@@ -136,12 +142,14 @@ case "$DISTRO_VERS" in
  "6.5")
     build_centos_65
     ;;
+ "6.6")
+    build_centos_66
+    ;;
  "6.x")
     build_centos_6x
     ;;
  *)
     DISTRO_VERS="default"
-     # Centos 6.6 is current default
-    build_centos_6x
+    build_centos_66
     ;;
 esac


### PR DESCRIPTION
We need to handle VSM_PATCH and have Centos 6.6 builds like VSM.
