### PR TITLE
Silence annoying output from S3_abort_multipart_upload

### DIFF
--- a/src/multipart.c
+++ b/src/multipart.c
@@ -73,8 +73,9 @@ static void AbortMultipartUploadCompleteCallback
 {    
     (void) callbackData;
     (void) s3ErrorDetails;
-    fprintf(stderr, "\nERROR: %s\n", S3_get_status_name(requestStatus));
-    
+    if (requestStatus != S3StatusOK) {
+        fprintf(stderr, "\nERROR: %s\n", S3_get_status_name(requestStatus));
+    }
 }
 
 static S3Status initialMultipartXmlCallback(const char *elementPath,


### PR DESCRIPTION
The AbortMultipartUploadCompleteCallback forced by the use
of S3_abort_multipart_upload was always printing the status
even if it was successful.  This was causing some annoying
output in the smoke tests.
