### PR TITLE
Template RPM spec file from git tag versioning

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -331,13 +331,26 @@ $(foreach i, $(ALL_SOURCES), $(eval -include $(BUILD)/dep/src/$(i:%.c=%.dd)))
 GIT_TARNAME = libs3-$(FULL_VERSION)
 GIT_TARPATH = $(BUILD)/$(GIT_TARNAME)
 
-dist: $(BUILD)
+dist: $(BUILD) libs3.spec
 	$(VERBOSE_SHOW) git archive --format=tar --prefix=$(GIT_TARNAME)/ HEAD^{tree} > $(GIT_TARPATH).tar
 	$(VERBOSE_SHOW) mkdir -p $(GIT_TARNAME)
 	$(VERBOSE_SHOW) cp GIT-VERSION-FILE $(GIT_TARNAME)
-	$(VERBOSE_SHOW) tar -rf $(GIT_TARPATH).tar $(GIT_TARNAME)/GIT-VERSION-FILE
+	$(VERBOSE_SHOW) cp $(BUILD)/libs3.spec $(GIT_TARNAME)
+	$(VERBOSE_SHOW) tar -rf $(GIT_TARPATH).tar $(GIT_TARNAME)/GIT-VERSION-FILE $(GIT_TARNAME)/libs3.spec
 	$(VERBOSE_SHOW) rm -r $(GIT_TARNAME)
 	$(VERBOSE_SHOW) gzip -f -9 $(GIT_TARPATH).tar
+
+# --------------------------------------------------------------------------
+# Redhat RPM target
+
+# RPM releases can't have -
+RPM_RELEASE := $(shell echo $(RELEASE) | tr '-' '.')
+
+%.spec: %.spec.in .FORCE $(BUILD)
+	$(VERBOSE_SHOW) sed -e 's/@@VERSION@@/$(VERSION)/g' \
+		-e s'/@@TAR_NAME@@/$(GIT_TARNAME)/g' \
+		-e s'/@@RELEASE@@/$(RPM_RELEASE)/g' < $< > $@+
+	$(VERBOSE_SHOW) mv $@+ $(BUILD)/$@
 
 # --------------------------------------------------------------------------
 # Debian package target

--- a/libs3.spec.in
+++ b/libs3.spec.in
@@ -1,16 +1,20 @@
-%{!?_version: %global _version 2.1}
+%define _version @@VERSION@@
+%define _tar_name @@TAR_NAME@@
+%define _release_extra @@RELEASE@@
+# official builds set this to 1, we use 0 for internal/dev-test
+%{!?_release: %global _release 0}
+
 # add on official "dot" if we have a patched version
-%global release_vsm_patch %{?vsm_patch:.%{vsm_patch}}
-%global source_vsm_patch %{?vsm_patch:-%{vsm_patch}}
+%global release_patch %{?_release_extra:.%{_release_extra}}
 
 Summary: C Library and Tools for Amazon S3 Access
 Name: libs3
 Version: %{_version}
-Release: vsm%{release_vsm_patch}%{?dist}
+Release: %{_release}%{release_patch}%{?dist}
 License: LGPL
 Group: Networking/Utilities
 URL: http://sourceforge.net/projects/reallibs3
-Source0: %{name}-%{version}%{source_vsm_patch}.tar.gz
+Source0: %{_tar_name}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}%{source_vsm_patch}-root
 # Want to include curl dependencies, but older Fedora Core uses curl-devel,
 # and newer Fedora Core uses libcurl-devel ... have to figure out how to
@@ -56,7 +60,7 @@ http://s3.amazonaws.com).  Its design goals are:
 
 
 %prep
-%setup -q -n %{name}-%{version}%{source_vsm_patch}
+%setup -q -n %{_tar_name}
 
 %build
 BUILD=$RPM_BUILD_ROOT/build make exported


### PR DESCRIPTION
In order to easily build RPMs from source, using the git version tags is
necessary.  At the end, we have RPMS built simply and from the git tag
information.  This will allow both release and dev/test activities to
use sane versioning that references directly back to git commits.

We add in templating of libs3.spec to allow for a .spec file
to be created and included in the .tar.gz for 'make dist'. Including
libs3.spec that has the proper variables defined allows us to use
rpmbuild -ts|rpmbuild --rebuild without passing down any magic data as
well.

Example RPM session:
$ make dist

$ rpmbuild -ts build/libs3-2.1-vsm-5-g5b86c3b.tar.gz
Wrote:
/home/vagrant/rpmbuild/SRPMS/libs3-2.1-0.vsm.5.g5b86c3b.el6.src.rpm

$ rpmbuild --rebuild
/home/vagrant/rpmbuild/SRPMS/libs3-2.1-0.vsm.5.g5b86c3b.el6.src.rpm
...
Wrote: /home/vagrant/rpmbuild/RPMS/x86_64/libs3-2.1-0.vsm.5.g5b86c3b.el6.x86_64.rpm
Wrote: /home/vagrant/rpmbuild/RPMS/x86_64/libs3-devel-2.1-0.vsm.5.g5b86c3b.el6.x86_64.rpm
...
