### PR TITLE
VSM-1052 push RPM artifacts back to pkg-linux

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -353,6 +353,7 @@ RPM_RELEASE := $(shell echo $(RELEASE) | tr '-' '.')
 	$(VERBOSE_SHOW) mv $@+ $(BUILD)/$@
 
 RPM_DIR = $(BUILD)/rpmbuild
+export RESULT_DIR = $(PWD)/pkg-linux/libs3-$(FULL_VERSION)
 
 rpm: dist
 	@mkdir -p $(RPM_DIR)


### PR DESCRIPTION
The move to have libs3 artifacts be in the toplevel is a special case
for our infrastructure, so unwind that a bit by overriding RESULT_DIR.
