### PR TITLE
VSM-993 use the spec file for pkg_name

### DIFF
--- a/pkg-linux/mock_rpmbuild.sh
+++ b/pkg-linux/mock_rpmbuild.sh
@@ -66,8 +66,9 @@ fi
 FULL_VERSION=$(awk -F ' = ' '/FULL_VERSION/ {print $NF}' "$VERSION_FILE")
 VERSION=$(awk -F ' = ' '/^VERSION/ {print $NF}' "$VERSION_FILE")
 
-# package name is the first word in the source tar
-PKG_NAME=$(basename "$SOURCE_TAR" | awk -F '-' '{print $1}')
+# we require a convention that is pkg_name.spec, so use it...
+SPEC_NAME=$(basename "$SOURCE_SPEC")
+PKG_NAME="${SPEC_NAME%.*}"
 
 # To find build requirements
 VSM_REPO=${VSM_REPO:-"vsm_master"}


### PR DESCRIPTION
We are already templating the pkg_name into our spec files, so don't
do any tricky parsing to find it. This comes into play with vsm-utils,
as that has a hyphen in the name and breaks the existing parsing.

This is a copying of the code from the vsm repo.
