### PR TITLE
VSM-1178 update spec to be RHEL agnostic

### DIFF
--- a/libs3.spec.in
+++ b/libs3.spec.in
@@ -66,7 +66,10 @@ http://s3.amazonaws.com).  Its design goals are:
 BUILD=$RPM_BUILD_ROOT/build make exported
 
 %install
-BUILD=$RPM_BUILD_ROOT/build DESTDIR=$RPM_BUILD_ROOT/usr make install
+BUILD=$RPM_BUILD_ROOT/build DESTDIR=$RPM_BUILD_ROOT/usr LIBDIR=$RPM_BUILD_ROOT/%{_libdir} make install
+
+# need 0755 for find-provides and other bits to recognize it
+chmod 0755 $RPM_BUILD_ROOT/%{_libdir}/libs3.so.*
 rm -rf $RPM_BUILD_ROOT/build
 
 %clean
@@ -75,12 +78,12 @@ rm -rf $RPM_BUILD_ROOT
 %files
 %defattr(-,root,root,-)
 /usr/bin/s3
-/usr/lib/libs3.so*
+%{_libdir}/libs3.so*
 
 %files devel
 %defattr(-,root,root,-)
 /usr/include/libs3.h
-/usr/lib/libs3.a
+%{_libdir}/libs3.a
 
 %changelog
 * Sat Aug 09 2008  <bryan@ischo,com> Bryan Ischo


### PR DESCRIPTION
On RHEL7, we need to move install to lib64 as that is the correct spot.
We can use the _libdir macro to get RPM to figure this out for us across
the different OS versions.

We also need to chmod the .so, as those permissions is how the automatic
find-provides process picks up the .so and adds our library to the
dependencies we provide.
