### PR TITLE
Add "Accept: application/xml" headers to requests

### DIFF
--- a/src/request.c
+++ b/src/request.c
@@ -958,6 +958,9 @@ static S3Status setup_curl(Request *request,
     append_standard_header(rangeHeader);
     append_standard_header(authorizationHeader);
 
+    request->headers = curl_slist_append(request->headers,
+                                         "Accept: application/xml");
+
     // Append x-amz- headers
     int i;
     for (i = 0; i < values->amzHeadersCount; i++) {


### PR DESCRIPTION
Adding the "Accept: application/xml" tells the server to send responses
back encoded with xml.  This is the only valid response from AWS
compliant systems, so is generally not needed.

Customer internal service is sending JSON responses without this header.
