### PR TITLE
Travis migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+language: bash
+sudo: required
+dist: trusty
+services: docker
+
+notifications:
+  slack:
+      secure: "uF5jtMi2cSMKdcsFieYlnruHTApd5GudTCAIh/AJmuv5zO/4sU8O0VV8uTXee4MtP+pbtuBjWMnF+cG0T9Kmn41bUwj0+TYqCDiTqgTy+56jseNylFNif+DjoO7xPEefBb8D+KyGX0Zp8BxtyowCUl4KckTyCe2xQ0uu/kgySo0="
+  on_success: always # default: always
+  on_failure: always # default: always
+
+
+deploy:
+  - provider: script
+    script: /bin/bash -x $TRAVIS_BUILD_DIR/.travis_deploy.sh
+    skip_cleanup: true
+    on:
+      tags: true
+      all_branches: true
+
+env:
+  matrix:
+    - VERSION=el7x DISTRO_VERS=7.x DISTRO=.el7
+    - VERSION=el6x DISTRO_VERS=6.x DISTRO=.el6
+
+before_script:
+  - env | sort
+  - mkdir -p upload_rpms/$DISTRO_VERS
+
+script:
+  - travis_wait docker run --privileged=true -e USER=root -e DISTRO=$DISTRO -e DISTRO_VERS=$DISTRO_VERS -e PWD=/src --rm -v $(pwd):/src -w /src versity/rpm-build:${VERSION} make rpm
+  - find build -name "*${DISTRO}*.x86_64.rpm" | xargs -n1 cp --target-directory=$(pwd)/upload_rpms/$DISTRO_VERS
+
+before_deploy:
+  - ls -la upload_rpms/
+
+  - wget https://dl.bintray.com/jfrog/jfrog-cli-go/1.7.1/jfrog-cli-linux-amd64/jfrog
+  - chmod +x jfrog
+  - ./jfrog rt config --url $ARTIFACTORY_URL --user $ARTIFACTORY_USER --password $ARTIFACTORY_PASSWORD
+
+# vim:set et ts=2 sw=2:

--- a/.travis_deploy.sh
+++ b/.travis_deploy.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -x
+
+# upload to our artifactory repo for public rpms
+
+if [[ -z "${DISTRO_VERS}" ]]; then
+    echo "ERROR: DISTRO_VERS must be set to your minor OS version (e.g. 6.9, 7.4.1708)"
+    exit 1
+fi
+
+case "${DISTRO_VERS}" in
+    "7.x")
+        EL_VERSION="7.4.1708"
+        ;;
+    "7.3")
+        EL_VERSION="7.3.1611"
+        ;;
+    "6.x")
+        EL_VERSION="6.9"
+        ;;
+    "*")
+        echo "Undetected patch level"
+        exit 1
+        ;;
+esac
+
+REPO="public-rpms/${EL_VERSION}/"
+
+PATTERN="${DISTRO_VERS}/*.rpm"
+
+./jfrog rt upload "upload_rpms/${PATTERN}" "${REPO}"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -355,16 +355,16 @@ RPM_RELEASE := $(shell echo $(RELEASE) | tr '-' '.')
 		-e s'/@@RELEASE@@/$(RPM_RELEASE)/g' < $< > $@+
 	$(VERBOSE_SHOW) mv $@+ $(BUILD)/$@
 
-RPM_DIR = $(BUILD)/rpmbuild
+RPM_DIR = $(PWD)/$(BUILD)/rpmbuild
 export RESULT_DIR = $(PWD)/pkg-linux/libs3-$(FULL_VERSION)
 
 rpm: dist
 	@mkdir -p $(RPM_DIR)
-	env RPM_DIR=$(RPM_DIR) bash ./pkg-linux/mock_rpmbuild.sh $(GIT_TARPATH).tar.gz $(BUILD)/libs3.spec
+	env RPM_DIR=$(RPM_DIR) rpmbuild.sh $(GIT_TARPATH).tar.gz
 
 relrpm: dist
 	@mkdir -p $(RPM_DIR)
-	env RPM_DIR=$(RPM_DIR) REL_BUILD="yes" bash ./pkg-linux/mock_rpmbuild.sh $(GIT_TARPATH).tar.gz $(BUILD)/libs3.spec
+	env RPM_DIR=$(RPM_DIR) REL_BUILD="yes" rpmbuild.sh $(GIT_TARPATH).tar.gz
 
 # --------------------------------------------------------------------------
 # Debian package target


### PR DESCRIPTION
- Deprecate mock, tweak for rpmbuild (i.e. adjust RPM_DIR)
- Basic config that builds RPMs in Docker for el6 and el7
- Deployment script that puts RPMs in the right place