### PR TITLE
fix issue with server Etag response

### DIFF
--- a/src/response_headers_handler.c
+++ b/src/response_headers_handler.c
@@ -26,6 +26,7 @@
 
 #include <ctype.h>
 #include <string.h>
+#include <strings.h>
 #include "response_headers_handler.h"
 
 
@@ -144,7 +145,8 @@ void response_headers_handler_add(ResponseHeadersHandler *handler,
         string_multibuffer_add(handler->responsePropertyStrings, c, 
                                valuelen, fit);
     }
-    else if (!strncmp(header, "ETag", namelen)) {
+    else if ((!strncasecmp(header, "ETag", namelen)) 
+         || (!strncasecmp(header, "Etag", namelen))) { // some servers reply with Etag header
         responseProperties->eTag = 
             string_multibuffer_current(handler->responsePropertyStrings);
         string_multibuffer_add(handler->responsePropertyStrings, c, 

--- a/src/s3.c
+++ b/src/s3.c
@@ -483,6 +483,7 @@ static void growbuffer_read(growbuffer **gb, int amt, int *amtReturn,
             buf->next->prev = buf->prev;
         }
         free(buf);
+        buf = NULL;
     }
 }
 
@@ -2419,6 +2420,7 @@ static void put_object(int argc, char **argv, int optindex,
                         MULTIPART_CHUNK_SIZE);
 
         MultipartPartData partData;
+        memset(&partData, 0, sizeof(MultipartPartData));
         int partContentLength = 0;
 
         S3MultipartInitialHandler handler = {
@@ -2469,10 +2471,11 @@ static void put_object(int argc, char **argv, int optindex,
 upload:
         todoContentLength -= MULTIPART_CHUNK_SIZE * manager.next_etags_pos;
         for (seq = manager.next_etags_pos + 1; seq <= totalSeq; seq++) {
-            memset(&partData, 0, sizeof(MultipartPartData));
             partData.manager = &manager;
             partData.seq = seq;
-            partData.put_object_data = data;
+            if (partData.put_object_data.gb==NULL) {
+              partData.put_object_data = data;
+            }
             partContentLength = ((contentLength > MULTIPART_CHUNK_SIZE) ?
                                  MULTIPART_CHUNK_SIZE : contentLength);
             printf("%s Part Seq %d, length=%d\n", srcSize ? "Copying" : "Sending", seq, partContentLength);


### PR DESCRIPTION
The minio server ETag response uses lowercase "t" as in Etag while all others so far have been using upper "T" as in ETag.  Allow for both options.