### PR TITLE
Fix more case insensitive matches for response headers

### DIFF
--- a/src/response_headers_handler.c
+++ b/src/response_headers_handler.c
@@ -114,45 +114,44 @@ void response_headers_handler_add(ResponseHeadersHandler *handler,
 
     int valuelen = (end - c) + 1, fit;
 
-    if (!strncmp(header, "x-amz-request-id", namelen)) {
+    if (!strncasecmp(header, "x-amz-request-id", namelen)) {
         responseProperties->requestId = 
             string_multibuffer_current(handler->responsePropertyStrings);
         string_multibuffer_add(handler->responsePropertyStrings, c, 
                                valuelen, fit);
     }
-    else if (!strncmp(header, "x-amz-id-2", namelen)) {
+    else if (!strncasecmp(header, "x-amz-id-2", namelen)) {
         responseProperties->requestId2 = 
             string_multibuffer_current(handler->responsePropertyStrings);
         string_multibuffer_add(handler->responsePropertyStrings, c, 
                                valuelen, fit);
     }
-    else if (!strncmp(header, "Content-Type", namelen)) {
+    else if (!strncasecmp(header, "Content-Type", namelen)) {
         responseProperties->contentType = 
             string_multibuffer_current(handler->responsePropertyStrings);
         string_multibuffer_add(handler->responsePropertyStrings, c, 
                                valuelen, fit);
     }
-    else if (!strncmp(header, "Content-Length", namelen)) {
+    else if (!strncasecmp(header, "Content-Length", namelen)) {
         handler->responseProperties.contentLength = 0;
         while (*c) {
             handler->responseProperties.contentLength *= 10;
             handler->responseProperties.contentLength += (*c++ - '0');
         }
     }
-    else if (!strncmp(header, "Server", namelen)) {
+    else if (!strncasecmp(header, "Server", namelen)) {
         responseProperties->server = 
             string_multibuffer_current(handler->responsePropertyStrings);
         string_multibuffer_add(handler->responsePropertyStrings, c, 
                                valuelen, fit);
     }
-    else if ((!strncasecmp(header, "ETag", namelen)) 
-         || (!strncasecmp(header, "Etag", namelen))) { // some servers reply with Etag header
+    else if (!strncasecmp(header, "ETag", namelen)) {
         responseProperties->eTag = 
             string_multibuffer_current(handler->responsePropertyStrings);
         string_multibuffer_add(handler->responsePropertyStrings, c, 
                                valuelen, fit);
     }
-    else if (!strncmp(header, S3_METADATA_HEADER_NAME_PREFIX, 
+    else if (!strncasecmp(header, S3_METADATA_HEADER_NAME_PREFIX, 
                       sizeof(S3_METADATA_HEADER_NAME_PREFIX) - 1)) {
         // Make sure there is room for another x-amz-meta header
         if (handler->responseProperties.metaDataCount ==
@@ -191,7 +190,7 @@ void response_headers_handler_add(ResponseHeadersHandler *handler,
         metaHeader->name = copiedName;
         metaHeader->value = copiedValue;
     }
-    else if (!strncmp(header, "x-amz-server-side-encryption", namelen)) {
+    else if (!strncasecmp(header, "x-amz-server-side-encryption", namelen)) {
         if (!strncmp(c, "AES256", sizeof("AES256") - 1)) {
             responseProperties->usesServerSideEncryption = 1;
         }


### PR DESCRIPTION
Some servers (most notably Minio) send different case response headers
back to us.  This fixes the response header handling to ignore case.